### PR TITLE
Make lld version check more robust

### DIFF
--- a/mk/Makeconf
+++ b/mk/Makeconf
@@ -464,7 +464,7 @@ check_path_absolute = $(if $(patsubst /%,,$(2)),$(error Path $(1)=$(2) is not ab
 
 LDVERSION_f     = $(shell $(callld) -v | sed -e \
 		    $(if $(filter LLD,$(shell $(callld) -v)),\
-		     's/.* \([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/\1\2\3/',\
+		     '/.* \([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/{s//\1\2\3/;p;q}' -n,\
 		     's/.* \([0-9]\)\.\([^. ]*\).*/\1\2/'))
 LDNOWARNRWX_f   = $(call checkld,--no-warn-rwx-segments)
 GCCSYSLIBDIRS_f = $(shell $(callcc) -print-search-dirs | sed '/^libraries:/{s/^libraries: =\?/-L/;s/:/ -L/g;q;};d')


### PR DESCRIPTION
Modified or downstream versions of lld might extend the --version
output to include further lines of information. This change tightens
up the sed command so that it will only extract a version number
appearing after the name "LLD"; quit after printing the first one it
finds; and not emit additional lines of --version text that don't
include a version number at all.

"Contribution covered by the CLA"
